### PR TITLE
correct documentation of literal # in fake_digits

### DIFF
--- a/lib/Data/Fake/Core.pm
+++ b/lib/Data/Fake/Core.pm
@@ -235,8 +235,8 @@ sub fake_float {
 
 =func fake_digits
 
-    $generator = fake_digits("###-####"); # "555-1234"
-    $generator = fake_digits("\###");     # "#12"
+    $generator = fake_digits('###-####'); # "555-1234"
+    $generator = fake_digits('\###');     # "#12"
 
 Given a text pattern, returns a generator that replaces all occurrences of
 the sharp character (C<#>) with a randomly selected digit.  To have a


### PR DESCRIPTION
This time I tested first. ;)

```
~$ perl -MData::Fake=Core -E 'say fake_digits(qq<\###>)->()'
103
~$ perl -MData::Fake=Core -E 'say fake_digits( q<\###>)->()'
#65
```

In a qq string, the `\#` sequence becomes `#`.  You need to use `"\\#"` or `'\#'`.  I have opted to suggest the latter.
